### PR TITLE
Update config_flow.py

### DIFF
--- a/custom_components/bluetti_bt/config_flow.py
+++ b/custom_components/bluetti_bt/config_flow.py
@@ -150,7 +150,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             if user_input[CONF_MAX_RETRIES] < 1:
                 return self.async_abort(reason="invalid_retries")
 
-            changed = self.hass.config_entries.async_update_entry(
+            self.hass.config_entries.async_update_entry(
                 self.config_entry,
                 data={
                     **self.config_entry.data,
@@ -163,11 +163,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     },
                 },
             )
-            if changed is False:
-                _LOGGER.error(
-                    "Method OptionsFlowHandler.async_step_init: Config entry %s has not been changed",
-                    self.config_entry.entry_id,
-                )
             return self.async_create_entry(
                 title="",
                 data={


### PR DESCRIPTION
fix this bug: OptionsFlowHandler.async_step_init: Config entry f3a445b566f0876e0d79f02059b7cb2a has not been changed.


Tested and work on lastest update of HA. I don't know if it is usefull to keep it in the code if it's trow me error and stop the integration from working.

AC200L