### PR TITLE
Add support for Bluetti AC2A

### DIFF
--- a/custom_components/bluetti_bt/bluetti_bt_lib/devices/ac2a.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/devices/ac2a.py
@@ -1,0 +1,38 @@
+"""AC2A fields."""
+
+from typing import List
+
+from ..base_devices.ProtocolV2Device import ProtocolV2Device
+from ..utils.commands import ReadHoldingRegisters
+
+
+class AC2A(ProtocolV2Device):
+    def __init__(self, address: str, sn: str):
+        super().__init__(address, "AC2A", sn)
+
+        # Core fields
+        self.struct.add_uint_field('total_battery_percent', 102)
+        self.struct.add_swap_string_field('device_type', 110, 6)
+        self.struct.add_sn_field('serial_number', 116)
+        self.struct.add_decimal_field('power_generation', 154, 1)  # Total kWh generated
+
+        # Power stats
+        self.struct.add_uint_field('dc_output_power', 140)
+        self.struct.add_uint_field('ac_output_power', 142)
+        self.struct.add_uint_field('dc_input_power', 144)
+        self.struct.add_uint_field('ac_input_power', 146)
+
+        # Status flags
+        self.struct.add_bool_field('ac_output_on', 1509)
+        self.struct.add_bool_field('dc_output_on', 2012)
+        self.struct.add_bool_field('power_lifting_on', 2021)
+
+    @property
+    def polling_commands(self) -> List[ReadHoldingRegisters]:
+        # Automatically generate polling ranges based on fields defined above
+        return self.struct.get_read_holding_registers()
+
+    @property
+    def writable_ranges(self) -> List[range]:
+        # Define if/where you want to support writing later (e.g. to toggle AC/DC outputs)
+        return super().writable_ranges

--- a/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
@@ -2,6 +2,7 @@
 
 import re
 
+from ..devices.ac2a import AC2A
 from ..devices.ac60 import AC60
 from ..devices.ac70 import AC70
 from ..devices.ac70p import AC70P
@@ -19,12 +20,14 @@ from ..devices.ep760 import EP760
 from ..devices.ep800 import EP800
 
 DEVICE_NAME_RE = re.compile(
-    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800)(\d+)$"
+    r"^(AC2A|AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800)(\d+)$"
 )
 
 
 def build_device(address: str, name: str):
     match = DEVICE_NAME_RE.match(name)
+    if match[1] == "AC2A":
+        return AC2A(address, match[2])
     if match[1] == "AC60":
         return AC60(address, match[2])
     if match[1] == "AC70":

--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -2,6 +2,7 @@
     "domain": "bluetti_bt",
     "name": "Bluetti BT",
     "bluetooth": [
+        { "local_name": "AC2A*" },
         { "local_name": "AC60*" },
         { "local_name": "AC70*" },
         { "local_name": "AC180*" },


### PR DESCRIPTION
This PR adds support for the Bluetti AC2A device to the integration.

Includes:
- New **ac2a.py** class under **devices/**, using **ProtocolV2Device**
- Register mappings for battery percent, AC/DC power, power lifting mode, etc.
- Added **AC2A** to the device regex and build logic in **device_builder.py**
- Added **AC2A*"** to the bluetooth discovery section in **manifest.json**

Confirmed working in Home Assistant:
- Device is auto-discovered via Bluetooth
- Sensors correctly show battery level, AC/DC output power and input when under load
- **ac_output_on**, **dc_output_on**, and other flags update in real time

Thanks for maintaining this excellent project. I hope my contribution will help other AC2A users.