### PR TITLE
Add support for Elite 30 V2

### DIFF
--- a/custom_components/bluetti_bt/bluetti_bt_lib/devices/el30v2.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/devices/el30v2.py
@@ -1,0 +1,8 @@
+"""Elite 30 V2 fields."""
+
+from ..base_devices.ProtocolV2Device import ProtocolV2Device
+
+
+class EL30V2(ProtocolV2Device):
+    def __init__(self, address: str, sn: str):
+        super().__init__(address, "EL30V2", sn)

--- a/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
@@ -17,9 +17,10 @@ from ..devices.ep500p import EP500P
 from ..devices.ep600 import EP600
 from ..devices.ep760 import EP760
 from ..devices.ep800 import EP800
+from ..devices.el30v2 import EL30V2
 
 DEVICE_NAME_RE = re.compile(
-    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800)(\d+)$"
+    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800|EL30V2)(\d+)$"
 )
 
 
@@ -55,6 +56,8 @@ def build_device(address: str, name: str):
         return EP760(address, match[2])
     if match[1] == "EP800":
         return EP800(address, match[2])
+    if match[1] == "EL30V2":
+        return EL30V2(address, match[2])
 
 
 def get_type_by_bt_name(bt_name: str):

--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -14,7 +14,8 @@
         { "local_name": "EP600*" },
         { "local_name": "EP760*" },
         { "local_name": "EP800*" },
-        { "local_name": "PBOX*" }
+        { "local_name": "PBOX*" },
+        { "local_name": "EL30V2*" }
     ],
     "codeowners": ["@Patrick762"],
     "config_flow": true,


### PR DESCRIPTION
Following similar structure to https://github.com/Patrick762/hassio-bluetti-bt/pull/184, adding support for the [Elite 30 V2](https://www.bluettipower.com.au/products/elite-30-v2-portable-power-station?_pos=1&_sid=1b3ebe955&_ss=r), with BLE advertised name EL30V2 