### PR TITLE
feat: add elite 100 v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ After the installation, you can use this button to install the integration:
 - EP600 (tested)
 - EP760 (basic data)
 - EP800 (basic data)
+- Elite 100 V2 (basic data)
 
 ### Available controls:
 If enabled in the Integration options (you need to reload the integration if you change this option):

--- a/custom_components/bluetti_bt/bluetti_bt_lib/devices/elite100v2.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/devices/elite100v2.py
@@ -1,0 +1,8 @@
+"""Elite 100 V2 fields."""
+
+from ..base_devices.ProtocolV2Device import ProtocolV2Device
+
+
+class Elite100V2(ProtocolV2Device):
+    def __init__(self, address: str, sn: str):
+        super().__init__(address, "Elite100V2", sn)

--- a/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
@@ -17,9 +17,10 @@ from ..devices.ep500p import EP500P
 from ..devices.ep600 import EP600
 from ..devices.ep760 import EP760
 from ..devices.ep800 import EP800
+from ..devices.elite100v2 import Elite100V2
 
 DEVICE_NAME_RE = re.compile(
-    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800)(\d+)$"
+    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800|EL100V2)(\d+)$"
 )
 
 
@@ -55,6 +56,8 @@ def build_device(address: str, name: str):
         return EP760(address, match[2])
     if match[1] == "EP800":
         return EP800(address, match[2])
+    if match[1] == "EL100V2":
+        return Elite100V2(address, match[2])
 
 
 def get_type_by_bt_name(bt_name: str):

--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -14,7 +14,8 @@
         { "local_name": "EP600*" },
         { "local_name": "EP760*" },
         { "local_name": "EP800*" },
-        { "local_name": "PBOX*" }
+        { "local_name": "PBOX*" },
+        { "local_name": "EL100V2*" }
     ],
     "codeowners": ["@Patrick762"],
     "config_flow": true,

--- a/tests/device_builder_test.py
+++ b/tests/device_builder_test.py
@@ -18,6 +18,7 @@ from custom_components.bluetti_bt.bluetti_bt_lib.devices.ep500p import EP500P
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ep600 import EP600
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ep760 import EP760
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ep800 import EP800
+from custom_components.bluetti_bt.bluetti_bt_lib.devices.elite100v2 import Elite100V2
 
 
 class TestDeviceBuilder(unittest.TestCase):
@@ -145,6 +146,14 @@ class TestDeviceBuilder(unittest.TestCase):
         built = build_device(bt_addr, bt_name)
 
         self.assertIsInstance(built, EP800)
+        self.assertEqual(built.address, bt_addr)
+
+    def test_build_Elite100V2(self):
+        bt_addr = "aa:bb:cc:dd:ee:ff"
+        bt_name = "EL100V20123456789012"
+        built = build_device(bt_addr, bt_name)
+
+        self.assertIsInstance(built, Elite100V2)
         self.assertEqual(built.address, bt_addr)
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds support for the new Elite 100 V2. This device requires the encryption functionality out-of-the-box.  But I've been able to verify the encryption functionality is working for this device, connected via an ESPHome BT Proxy.