### PR TITLE
Add support for AC200PL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ After the installation, you can use this button to install the integration:
 - AC180P (tested)
 - AC200L (untested)
 - AC200M
+- AC200PL (untested)
 - AC300 (tested)
 - AC500 (tested)
 - EB3A

--- a/custom_components/bluetti_bt/bluetti_bt_lib/devices/ac200pl.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/devices/ac200pl.py
@@ -1,0 +1,56 @@
+"""AC200PL fields."""
+
+from typing import List
+
+from ..utils.commands import ReadHoldingRegisters
+from ..field_enums import AutoSleepMode, OutputMode
+from ..base_devices.ProtocolV1Device import ProtocolV1Device
+
+
+class AC200PL(ProtocolV1Device):
+    def __init__(self, address: str, sn: str):
+        super().__init__(address, "AC200PL", sn)
+
+        # Details
+        self.struct.add_enum_field("ac_output_mode", 70, OutputMode)
+        self.struct.add_decimal_field("internal_ac_voltage", 71, 1, multiplier=10)
+        self.struct.add_decimal_field("internal_current_one", 72, 1)
+        self.struct.add_uint_field("internal_power_one", 73)
+        self.struct.add_decimal_field("internal_ac_frequency", 74, 2, multiplier=10)
+        self.struct.add_uint_field("internal_dc_input_voltage", 86, multiplier=.1)
+        self.struct.add_decimal_field("internal_dc_input_power", 87, 1, multiplier=10)
+        self.struct.add_decimal_field("internal_dc_input_current", 88, 2)
+
+        # Battery packs
+        self.struct.add_uint_field("pack_num_max", 91)  # internal
+        self.struct.add_decimal_field("total_battery_voltage", 92, 1, multiplier=.1)
+        self.struct.add_uint_field("pack_num_result", 96)  # internal
+        self.struct.add_decimal_field("pack_voltage", 98, 2)  # Full pack voltage
+        self.struct.add_uint_field("pack_battery_percent", 99)
+        self.struct.add_decimal_array_field("cell_voltages", 105, 16, 2)  # internal
+        self.struct.add_version_field("pack_bms_version", 201)
+
+        # Controls
+        self.struct.add_bool_field("power_off", 3060)
+        self.struct.add_enum_field("auto_sleep_mode", 3061, AutoSleepMode)
+
+    @property
+    def pack_num_max(self):
+        return 3
+
+    @property
+    def polling_commands(self) -> List[ReadHoldingRegisters]:
+        return self.struct.get_read_holding_registers(
+            filter=lambda address: address <= 90 or address >= 256 # pack_polling_commands
+        )
+
+    @property
+    def writable_ranges(self) -> List[range]:
+        return super().writable_ranges + [range(3060, 3062)]
+
+    @property
+    def pack_polling_commands(self) -> List[ReadHoldingRegisters]:
+        return [
+            ReadHoldingRegisters(91, 37),
+            ReadHoldingRegisters(201, 2),
+        ]

--- a/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
+++ b/custom_components/bluetti_bt/bluetti_bt_lib/utils/device_builder.py
@@ -9,6 +9,7 @@ from ..devices.ac180 import AC180
 from ..devices.ac180p import AC180P
 from ..devices.ac200l import AC200L
 from ..devices.ac200m import AC200M
+from ..devices.ac200pl import AC200PL
 from ..devices.ac300 import AC300
 from ..devices.ac500 import AC500
 from ..devices.eb3a import EB3A
@@ -19,7 +20,7 @@ from ..devices.ep760 import EP760
 from ..devices.ep800 import EP800
 
 DEVICE_NAME_RE = re.compile(
-    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800)(\d+)$"
+    r"^(AC60|AC70|AC70P|AC180|AC180P|AC200L|AC200M|AC200PL|AC300|AC500|EB3A|EP500|EP500P|EP600|EP760|EP800)(\d+)$"
 )
 
 
@@ -39,6 +40,8 @@ def build_device(address: str, name: str):
         return AC200L(address, match[2])
     if match[1] == "AC200M":
         return AC200M(address, match[2])
+    if match[1] == "AC200PL":
+        return AC200PL(address, match[2])
     if match[1] == "AC300":
         return AC300(address, match[2])
     if match[1] == "AC500":

--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -7,6 +7,7 @@
         { "local_name": "AC180*" },
         { "local_name": "AC200L*" },
         { "local_name": "AC200M*" },
+        { "local_name": "AC200PL*" },
         { "local_name": "AC300*" },
         { "local_name": "AC500*" },
         { "local_name": "EB3A*" },

--- a/tests/device_builder_test.py
+++ b/tests/device_builder_test.py
@@ -10,6 +10,7 @@ from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac180 import AC180
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac180p import AC180P
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac200l import AC200L
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac200m import AC200M
+from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac200pl import AC200PL
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac300 import AC300
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.ac500 import AC500
 from custom_components.bluetti_bt.bluetti_bt_lib.devices.eb3a import EB3A
@@ -81,6 +82,14 @@ class TestDeviceBuilder(unittest.TestCase):
         built = build_device(bt_addr, bt_name)
 
         self.assertIsInstance(built, AC200M)
+        self.assertEqual(built.address, bt_addr)
+
+    def test_build_ac200pl(self):
+        bt_addr = "aa:bb:cc:dd:ee:ff"
+        bt_name = "AC200PL56786746478"
+        built = build_device(bt_addr, bt_name)
+
+        self.assertIsInstance(built, AC200PL)
         self.assertEqual(built.address, bt_addr)
 
     def test_build_ac300(self):


### PR DESCRIPTION
Adds support for AC200PL based on information from dpb03 in issue #112. Initial tests on two AC200PL devices appear successful. Based on existing support for AC200L. No new features added.