### PR TITLE
Fix migration from v0.1.6 to v0.2.x

### DIFF
--- a/custom_components/bluetti_bt/__init__.py
+++ b/custom_components/bluetti_bt/__init__.py
@@ -36,6 +36,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     config = FullDeviceConfig.from_dict(entry.data)
 
     if config is None:
+        logging.getLogger(__name__).error(
+            "Failed to parse config entry data for '%s'. "
+            "This may happen when upgrading from v0.1.6 to v0.2.x "
+            "due to missing 'use_encryption' field.",
+            entry.title,
+        )
         return False
 
     logger = logging.getLogger(

--- a/custom_components/bluetti_bt/coordinator.py
+++ b/custom_components/bluetti_bt/coordinator.py
@@ -33,15 +33,15 @@ class PollingCoordinator(DataUpdateCoordinator):
         )
 
         self.config = config
+        self.reader = None
 
         # Create client
         self.logger.info("Creating client for %s", config.name)
         bluetti_device = build_device(config.name)
 
         if bluetti_device is None:
-            self.logger.error("Device is unknown type")
-            self.async_shutdown()
-            return None
+            self.logger.error("Device is unknown type: %s", config.name)
+            return
 
         self.reader = DeviceReader(
             config.address,
@@ -69,6 +69,14 @@ class PollingCoordinator(DataUpdateCoordinator):
             is False
         ):
             self.logger.warning("Device not connected")
+            self.last_update_success = False
+            return None
+
+        if self.reader is None:
+            self.logger.error(
+                "Reader not initialized - device type may be unsupported: %s",
+                self.config.name,
+            )
             self.last_update_success = False
             return None
 

--- a/custom_components/bluetti_bt/types/InitialDeviceConfig.py
+++ b/custom_components/bluetti_bt/types/InitialDeviceConfig.py
@@ -28,7 +28,7 @@ class InitialDeviceConfig:
             raw.get(CONF_ADDRESS),
             raw.get(CONF_NAME),
             raw.get(CONF_TYPE),
-            raw.get(CONF_USE_ENCRYPTION),
+            raw.get(CONF_USE_ENCRYPTION, False),
         )
 
     @property
@@ -46,5 +46,5 @@ class InitialDeviceConfig:
             isinstance(raw.get(CONF_ADDRESS), str)
             and isinstance(raw.get(CONF_NAME), str)
             and isinstance(raw.get(CONF_TYPE), str)
-            and isinstance(raw.get(CONF_USE_ENCRYPTION), bool)
+            and isinstance(raw.get(CONF_USE_ENCRYPTION, False), bool)
         )


### PR DESCRIPTION
## Summary

Fixes #211 and #225 - Integration fails to start after upgrading from v0.1.6 to v0.2.x.

### Root Cause

When upgrading from v0.1.6, the config entry data does not contain the `use_encryption` field introduced in v0.2.0. This causes three cascading failures:

1. **`InitialDeviceConfig.has_values()` returns `False`** because `isinstance(None, bool)` is `False` when `use_encryption` is missing from the stored config data
2. **`FullDeviceConfig.from_dict()` returns `None`**, so `async_setup_entry()` silently returns `False`
3. **`PollingCoordinator` crashes with `AttributeError`** (`'PollingCoordinator' object has no attribute 'reader'`) when `build_device()` returns `None` and the constructor exits before assigning `self.reader`

### Changes

- **`types/InitialDeviceConfig.py`**: Default `use_encryption` to `False` when missing from config data (backward compatibility with v0.1.6 config entries)
- **`coordinator.py`**: Initialize `self.reader = None` before device creation, add safety check in `_async_update_data()` to prevent `AttributeError`
- **`__init__.py`**: Add diagnostic error logging when config parsing fails, pointing users to the migration issue

### Testing

Tested successfully on **Home Assistant 2026.2.3** with a **Bluetti AC300** device (BT address `04:7F:0E:A8:C3:DB`):
- Upgraded directly from v0.1.6 to v0.2.1 with this patch
- All sensors restored and working correctly
- No errors in logs

### Before this fix
```
AttributeError: 'PollingCoordinator' object has no attribute 'reader'
```
Integration shows "Failed to setup" and all entities are unavailable.

### After this fix
Integration starts correctly, all sensors are available and updating via Bluetooth.