### PR TITLE
AP300: Add sensors, controls, and encrypted write support

### DIFF
--- a/custom_components/bluetti_bt/__init__.py
+++ b/custom_components/bluetti_bt/__init__.py
@@ -27,6 +27,7 @@ PLATFORMS: List[Platform] = [
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.SELECT,
+    Platform.NUMBER,
 ]
 
 

--- a/custom_components/bluetti_bt/binary_sensor.py
+++ b/custom_components/bluetti_bt/binary_sensor.py
@@ -44,8 +44,6 @@ async def async_setup_entry(
     sensors_to_add = []
     bool_fields = bluetti_device.get_bool_fields()
 
-    if config.use_encryption:
-        bool_fields = bool_fields + bluetti_device.get_switch_fields()
 
     for field in bool_fields:
         sensors_to_add.append(

--- a/custom_components/bluetti_bt/binary_sensor.py
+++ b/custom_components/bluetti_bt/binary_sensor.py
@@ -44,9 +44,6 @@ async def async_setup_entry(
     sensors_to_add = []
     bool_fields = bluetti_device.get_bool_fields()
 
-    if config.use_encryption:
-        bool_fields = bool_fields + bluetti_device.get_switch_fields()
-
     for field in bool_fields:
         sensors_to_add.append(
             BluettiBinarySensor(

--- a/custom_components/bluetti_bt/binary_sensor.py
+++ b/custom_components/bluetti_bt/binary_sensor.py
@@ -44,6 +44,8 @@ async def async_setup_entry(
     sensors_to_add = []
     bool_fields = bluetti_device.get_bool_fields()
 
+    if config.use_encryption:
+        bool_fields = bool_fields + bluetti_device.get_switch_fields()
 
     for field in bool_fields:
         sensors_to_add.append(

--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -30,6 +30,6 @@
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Patrick762/hassio-bluetti-bt/issues",
-    "requirements": ["bluetti-bt-lib==0.1.6"],
+    "requirements": ["bluetti-bt-lib@git+https://github.com/happytechca/bluetti-bt-lib.git@ap300-new-sensors"],
     "version": "0.2.1"
 }

--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -30,6 +30,6 @@
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Patrick762/hassio-bluetti-bt/issues",
-    "requirements": ["bluetti-bt-lib@git+https://github.com/happytechca/bluetti-bt-lib.git@ap300-new-sensors"],
+    "requirements": ["bluetti-bt-lib@git+https://github.com/happytechca/bluetti-bt-lib.git@main"],
     "version": "0.2.1"
 }

--- a/custom_components/bluetti_bt/number.py
+++ b/custom_components/bluetti_bt/number.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from bluetti_bt_lib import build_device, BluettiDevice, DeviceWriter, NumberField
+from bluetti_bt_lib import build_device, BluettiDevice, DeviceWriter, NumberField, FieldName
 
 from .types import FullDeviceConfig
 from . import device_info as dev_info, get_unique_id
@@ -153,6 +153,19 @@ class BluettiNumber(CoordinatorEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
+        # Guard: SOC min must be less than SOC max
+        data = self.coordinator.data or {}
+        if self._field.name == FieldName.BATTERY_SOC_RANGE_START.value:
+            soc_max = data.get(FieldName.BATTERY_SOC_RANGE_END.value)
+            if soc_max is not None and value >= soc_max:
+                self._logger.warning("SOC Min (%s) must be less than SOC Max (%s)", value, soc_max)
+                return
+        elif self._field.name == FieldName.BATTERY_SOC_RANGE_END.value:
+            soc_min = data.get(FieldName.BATTERY_SOC_RANGE_START.value)
+            if soc_min is not None and value <= soc_min:
+                self._logger.warning("SOC Max (%s) must be greater than SOC Min (%s)", value, soc_min)
+                return
+
         self._logger.debug(
             "Set %s on %s to %s", self._response_key, mac_loggable(self._address), value
         )

--- a/custom_components/bluetti_bt/number.py
+++ b/custom_components/bluetti_bt/number.py
@@ -1,0 +1,193 @@
+"""Bluetti BT number entities (sliders)."""
+
+from __future__ import annotations
+import asyncio
+import logging
+import async_timeout
+from bleak import BleakScanner
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from bluetti_bt_lib import build_device, BluettiDevice, DeviceWriter, NumberField
+
+from .types import FullDeviceConfig
+from . import device_info as dev_info, get_unique_id
+from .const import DATA_COORDINATOR, DATA_LOCK, DOMAIN
+from .coordinator import PollingCoordinator
+from .utils import mac_loggable, unique_id_logable
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Setup number entities."""
+
+    config = FullDeviceConfig.from_dict(entry.data)
+    coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+    lock = hass.data[DOMAIN][entry.entry_id][DATA_LOCK]
+
+    logger = logging.getLogger(
+        f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
+    )
+
+    if config is None or not isinstance(coordinator, PollingCoordinator):
+        logger.error("No coordinator found")
+        return None
+
+    logger.info("Creating number entities for device with address %s", config.address)
+    device_info = dev_info(entry)
+
+    bluetti_device = build_device(config.name)
+
+    entities_to_add = []
+    for field in bluetti_device.get_number_fields():
+        entities_to_add.append(
+            BluettiNumber(
+                bluetti_device,
+                config.address,
+                coordinator,
+                device_info,
+                field,
+                lock,
+                use_encryption=config.use_encryption,
+                logger=logger,
+            )
+        )
+
+    async_add_entities(entities_to_add)
+
+
+class BluettiNumber(CoordinatorEntity, NumberEntity):
+    """Bluetti universal number entity."""
+
+    def __init__(
+        self,
+        bluetti_device: BluettiDevice,
+        address: str,
+        coordinator: PollingCoordinator,
+        device_info: DeviceInfo,
+        field: NumberField,
+        lock: asyncio.Lock,
+        use_encryption: bool = False,
+        logger: logging.Logger = logging.getLogger(),
+    ):
+        """Init entity."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._logger = logger
+
+        e_name = f"{device_info.get('name')} {field.name}"
+        self._bluetti_device = bluetti_device
+        self._address = address
+        self._field = field
+        self._response_key = field.name
+        self._unavailable_counter = 5
+        self._lock = lock
+        self._use_encryption = use_encryption
+
+        self._attr_has_entity_name = True
+        self._attr_device_info = device_info
+        self._attr_translation_key = field.name
+        self._attr_available = False
+        self._attr_unique_id = get_unique_id(e_name)
+        self._attr_mode = NumberMode.SLIDER
+        self._attr_native_step = 1
+        self._attr_native_min_value = field.min if field.min is not None else 0
+        self._attr_native_max_value = field.max if field.max is not None else 100
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self._attr_available
+
+    def _set_available(self):
+        self._attr_available = True
+        self._unavailable_counter = 0
+        self._attr_extra_state_attributes = {}
+        self.async_write_ha_state()
+
+    def _set_unavailable(self, cause: str = "Unknown"):
+        self._unavailable_counter += 1
+        self._attr_extra_state_attributes = {
+            "unavailable_counter": self._unavailable_counter,
+            "unavailable_cause": cause,
+        }
+        if self._unavailable_counter >= 5:
+            self._attr_available = False
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+
+        if self.coordinator.data is None:
+            self._set_unavailable("Data is None")
+            return
+
+        if not isinstance(self.coordinator.data, dict):
+            self._set_unavailable("Invalid data")
+            return
+
+        response_data = self.coordinator.data.get(self._response_key)
+        if response_data is None:
+            self._set_unavailable("No data")
+            return
+
+        if not isinstance(response_data, (int, float)):
+            self._logger.warning(
+                "Invalid response data type from coordinator (number.%s): %s",
+                unique_id_logable(self._attr_unique_id),
+                response_data,
+            )
+            self._set_unavailable("Invalid data type")
+            return
+
+        self._set_available()
+        self._attr_native_value = response_data
+        self.async_write_ha_state()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set new value."""
+        self._logger.debug(
+            "Set %s on %s to %s", self._response_key, mac_loggable(self._address), value
+        )
+        await self.write_to_device(value)
+
+    async def write_to_device(self, value: float):
+        """Write to device."""
+
+        try:
+            if self._use_encryption:
+                await self.coordinator.reader.write(self._field.name, value)
+            else:
+                device = await BleakScanner.find_device_by_address(self._address, timeout=5)
+
+                if device is None:
+                    return
+
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    device,
+                    device.name or "Unknown Device",
+                    max_attempts=10,
+                )
+
+                if not client.is_connected:
+                    return
+
+                writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
+
+                async with async_timeout.timeout(15):
+                    await writer.write(self._field.name, int(value))
+                    await asyncio.sleep(5)
+
+        except TimeoutError:
+            self._logger.error("Timed out for device %s", mac_loggable(self._address))
+            return None
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/bluetti_bt/select.py
+++ b/custom_components/bluetti_bt/select.py
@@ -39,10 +39,6 @@ async def async_setup_entry(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
 
-    if config.use_encryption is True:
-        logger.info("Controls are disabled on encrypted devices")
-        return None
-
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
         return None

--- a/custom_components/bluetti_bt/select.py
+++ b/custom_components/bluetti_bt/select.py
@@ -39,10 +39,6 @@ async def async_setup_entry(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
 
-    if config.use_encryption is True:
-        logger.info("Controls are disabled on encrypted devices")
-        return None
-
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
         return None
@@ -67,6 +63,7 @@ async def async_setup_entry(
                 device_info,
                 field,
                 lock,
+                use_encryption=config.use_encryption,
                 category=category,
                 logger=logger,
             )
@@ -86,6 +83,7 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
         device_info: DeviceInfo,
         field: SelectField,
         lock: asyncio.Lock,
+        use_encryption: bool = False,
         category: EntityCategory | None = None,
         logger: logging.Logger = logging.getLogger(),
     ):
@@ -101,6 +99,7 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
         self._response_key = field.name
         self._unavailable_counter = 5
         self._lock = lock
+        self._use_encryption = use_encryption
         self._attr_options = [e.name for e in field.e]
 
         self._attr_has_entity_name = True
@@ -190,29 +189,29 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
         """Write to device."""
 
         try:
-            device = await BleakScanner.find_device_by_address(self._address, timeout=5)
+            if self._use_encryption:
+                await self.coordinator.reader.write(self._field.name, state)
+            else:
+                device = await BleakScanner.find_device_by_address(self._address, timeout=5)
 
-            if device is None:
-                return
+                if device is None:
+                    return
 
-            client = await establish_connection(
-                BleakClientWithServiceCache,
-                device,
-                device.name or "Unknown Device",
-                max_attempts=10,
-            )
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    device,
+                    device.name or "Unknown Device",
+                    max_attempts=10,
+                )
 
-            if not client.is_connected:
-                return
+                if not client.is_connected:
+                    return
 
-            writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
+                writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
 
-            async with async_timeout.timeout(15):
-                # Send command
-                await writer.write(self._field.name, state)
-
-                # Wait until device has changed value, otherwise reading register might reset it
-                await asyncio.sleep(5)
+                async with async_timeout.timeout(15):
+                    await writer.write(self._field.name, state)
+                    await asyncio.sleep(5)
 
         except TimeoutError:
             self._logger.error("Timed out for device %s", mac_loggable(self._address))

--- a/custom_components/bluetti_bt/select.py
+++ b/custom_components/bluetti_bt/select.py
@@ -39,6 +39,10 @@ async def async_setup_entry(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
 
+    if config.use_encryption is True:
+        logger.info("Controls are disabled on encrypted devices")
+        return None
+
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
         return None

--- a/custom_components/bluetti_bt/sensor.py
+++ b/custom_components/bluetti_bt/sensor.py
@@ -47,6 +47,8 @@ async def async_setup_entry(
     sensors_to_add = []
     sensor_fields = bluetti_device.get_sensor_fields()
 
+    if config.use_encryption:
+        sensor_fields = sensor_fields + bluetti_device.get_select_fields()
 
     for field in sensor_fields:
         field_name = FieldName(field.name)
@@ -57,7 +59,7 @@ async def async_setup_entry(
         unit = get_unit(field_name)
         device_class = get_device_class(field_name)
         state_class = get_state_class(field_name)
-        category = get_category(field_name)
+        category = None if config.use_encryption else get_category(field_name)
 
         if unit is not None:
             sensors_to_add.append(

--- a/custom_components/bluetti_bt/sensor.py
+++ b/custom_components/bluetti_bt/sensor.py
@@ -47,9 +47,6 @@ async def async_setup_entry(
     sensors_to_add = []
     sensor_fields = bluetti_device.get_sensor_fields()
 
-    if config.use_encryption:
-        sensor_fields = sensor_fields + bluetti_device.get_select_fields()
-
     for field in sensor_fields:
         field_name = FieldName(field.name)
 
@@ -59,7 +56,7 @@ async def async_setup_entry(
         unit = get_unit(field_name)
         device_class = get_device_class(field_name)
         state_class = get_state_class(field_name)
-        category = None if config.use_encryption else get_category(field_name)
+        category = get_category(field_name)
 
         if unit is not None:
             sensors_to_add.append(

--- a/custom_components/bluetti_bt/sensor.py
+++ b/custom_components/bluetti_bt/sensor.py
@@ -47,8 +47,6 @@ async def async_setup_entry(
     sensors_to_add = []
     sensor_fields = bluetti_device.get_sensor_fields()
 
-    if config.use_encryption:
-        sensor_fields = sensor_fields + bluetti_device.get_select_fields()
 
     for field in sensor_fields:
         field_name = FieldName(field.name)
@@ -59,7 +57,7 @@ async def async_setup_entry(
         unit = get_unit(field_name)
         device_class = get_device_class(field_name)
         state_class = get_state_class(field_name)
-        category = None if config.use_encryption else get_category(field_name)
+        category = get_category(field_name)
 
         if unit is not None:
             sensors_to_add.append(

--- a/custom_components/bluetti_bt/switch.py
+++ b/custom_components/bluetti_bt/switch.py
@@ -44,10 +44,6 @@ async def async_setup_entry(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
 
-    if config.use_encryption is True:
-        logger.info("Controls are disabled on encrypted devices")
-        return None
-
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
         return None
@@ -72,6 +68,7 @@ async def async_setup_entry(
                 device_info,
                 field,
                 lock,
+                use_encryption=config.use_encryption,
                 category=category,
                 logger=logger,
             )
@@ -91,6 +88,7 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
         device_info: DeviceInfo,
         field: DeviceField,
         lock: asyncio.Lock,
+        use_encryption: bool = False,
         category: EntityCategory | None = None,
         logger: logging.Logger = logging.getLogger(),
     ):
@@ -106,6 +104,7 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
         self._response_key = field.name
         self._unavailable_counter = 5
         self._lock = lock
+        self._use_encryption = use_encryption
 
         self._attr_has_entity_name = True
         self._attr_device_info = device_info
@@ -198,29 +197,29 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
         """Write to device."""
 
         try:
-            device = await BleakScanner.find_device_by_address(self._address, timeout=5)
+            if self._use_encryption:
+                await self.coordinator.reader.write(self._field.name, state)
+            else:
+                device = await BleakScanner.find_device_by_address(self._address, timeout=5)
 
-            if device is None:
-                return
+                if device is None:
+                    return
 
-            client = await establish_connection(
-                BleakClientWithServiceCache,
-                device,
-                device.name or "Unknown Device",
-                max_attempts=10,
-            )
+                client = await establish_connection(
+                    BleakClientWithServiceCache,
+                    device,
+                    device.name or "Unknown Device",
+                    max_attempts=10,
+                )
 
-            if not client.is_connected:
-                return
+                if not client.is_connected:
+                    return
 
-            writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
+                writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
 
-            async with async_timeout.timeout(15):
-                # Send command
-                await writer.write(self._field.name, state)
-
-                # Wait until device has changed value, otherwise reading register might reset it
-                await asyncio.sleep(5)
+                async with async_timeout.timeout(15):
+                    await writer.write(self._field.name, state)
+                    await asyncio.sleep(5)
 
         except TimeoutError:
             self._logger.error("Timed out for device %s", mac_loggable(self._address))

--- a/custom_components/bluetti_bt/switch.py
+++ b/custom_components/bluetti_bt/switch.py
@@ -23,6 +23,7 @@ from bluetti_bt_lib import (
     DeviceField,
     FieldName,
 )
+from bluetti_bt_lib.enums import WorkingMode
 
 from .types import FullDeviceConfig, get_category
 from . import device_info as dev_info, get_unique_id
@@ -160,6 +161,13 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
             )
             self._set_unavailable("Invalid data")
             return
+
+        # Charge from grid is only meaningful in Custom working mode
+        if self._field.name == FieldName.CTRL_CHARGE_FROM_GRID.value:
+            working_mode = self.coordinator.data.get(FieldName.CTRL_WORKING_MODE.value)
+            if working_mode is not WorkingMode.CUSTOM:
+                self._set_unavailable("Only available in Custom working mode")
+                return
 
         response_data = self.coordinator.data.get(self._response_key)
         if response_data is None:

--- a/custom_components/bluetti_bt/switch.py
+++ b/custom_components/bluetti_bt/switch.py
@@ -44,6 +44,10 @@ async def async_setup_entry(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
 
+    if config.use_encryption is True:
+        logger.info("Controls are disabled on encrypted devices")
+        return None
+
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
         return None

--- a/custom_components/bluetti_bt/switch.py
+++ b/custom_components/bluetti_bt/switch.py
@@ -44,10 +44,6 @@ async def async_setup_entry(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
 
-    if config.use_encryption is True:
-        logger.info("Controls are disabled on encrypted devices")
-        return None
-
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
         return None

--- a/custom_components/bluetti_bt/translations/en.json
+++ b/custom_components/bluetti_bt/translations/en.json
@@ -325,7 +325,13 @@
         "name": "UPS Mode"
       },
       "ctrl_working_mode": {
-        "name": "Working Mode"
+        "name": "Working Mode",
+        "state": {
+          "CUSTOM": "Custom",
+          "SELF_CONSUMPTION": "Self Consumption",
+          "BACKUP": "Backup",
+          "TIME_OF_USE": "Time of Use"
+        }
       }
     },
     "number": {

--- a/custom_components/bluetti_bt/translations/en.json
+++ b/custom_components/bluetti_bt/translations/en.json
@@ -304,7 +304,12 @@
     },
     "select": {
       "ctrl_charging_mode": {
-        "name": "Charging Mode"
+        "name": "Charging Mode",
+        "state": {
+          "STANDARD": "Standard",
+          "SILENT": "Silent",
+          "TURBO": "Turbo"
+        }
       },
       "ctrl_display_timeout": {
         "name": "Display Timeout"

--- a/custom_components/bluetti_bt/translations/en.json
+++ b/custom_components/bluetti_bt/translations/en.json
@@ -89,12 +89,6 @@
       "total_battery_percent": {
         "name": "Battery SOC"
       },
-      "soc_range_end": {
-        "name": "SOC high"
-      },
-      "soc_range_start": {
-        "name": "SOC low"
-      },
       "ctrl_eco_min_power_ac": {
         "name": "Eco Minimum Power AC"
       },
@@ -326,6 +320,14 @@
       },
        "ctrl_ups_mode": {
         "name": "UPS Mode"
+      }
+    },
+    "number": {
+      "soc_range_end": {
+        "name": "SOC High"
+      },
+      "soc_range_start": {
+        "name": "SOC Low"
       }
     },
     "binary_sensor": {

--- a/custom_components/bluetti_bt/translations/en.json
+++ b/custom_components/bluetti_bt/translations/en.json
@@ -312,7 +312,13 @@
         }
       },
       "ctrl_display_timeout": {
-        "name": "Display Timeout"
+        "name": "Display Timeout",
+        "state": {
+          "SEC30": "30 seconds",
+          "MIN1": "1 minute",
+          "MIN5": "5 minutes",
+          "NEVER": "Never"
+        }
       },
       "ctrl_eco_time_mode": {
         "name": "Eco Timer"

--- a/custom_components/bluetti_bt/translations/en.json
+++ b/custom_components/bluetti_bt/translations/en.json
@@ -116,7 +116,7 @@
       "ctrl_led_mode": {
         "name": "LED Mode"
       },
-       "ctrl_ups_mode": {
+      "ctrl_ups_mode": {
         "name": "UPS Mode"
       },
       "dc_input_current": {
@@ -297,6 +297,9 @@
       },
       "ctrl_power_off": {
         "name": "Poweroff"
+      },
+      "ctrl_charge_from_grid": {
+        "name": "Charge from Grid"
       }
     },
     "select": {
@@ -318,16 +321,19 @@
       "ctrl_led_mode": {
         "name": "LED Mode"
       },
-       "ctrl_ups_mode": {
+      "ctrl_ups_mode": {
         "name": "UPS Mode"
+      },
+      "ctrl_working_mode": {
+        "name": "Working Mode"
       }
     },
     "number": {
       "soc_range_end": {
-        "name": "SOC High"
+        "name": "SOC Max"
       },
       "soc_range_start": {
-        "name": "SOC Low"
+        "name": "SOC Min"
       }
     },
     "binary_sensor": {


### PR DESCRIPTION
Expands AP300 support with 18+ newly discovered BLE registers from my newly acquired Apex 300 unit.
Adds read sensors, writable controls, and a new `number` platform

**Fixes a long-standing gap where V2 encrypted devices couldn't write any controls.**

### New AP300 sensors
- AC input: frequency, voltage, current
- AC output: frequency, voltage
- DC/AC input/output power
- Time remaining

### New AP300 controls
- **Switches:** AC output, DC output, ECO mode, power lifting, charge from grid
- **Selects:** charging mode, working mode, display timeout
- **Number sliders:** battery SOC range start/end (0–100%)

### Encrypted write support (V2 devices)
Previously, switches and selects were silently demoted to read-only entities on all encrypted V2 devices because `DeviceWriter` lacks an encryption handshake.
This PR removes that blanket guard and routes writes through `DeviceReader.write()` (added in the companion library PR), which already has the required encryption infrastructure.

This affects all encrypted V2 devices that have switch/select fields defined in the library: **AC180, AC300, AC500, EP500P, EP600**.
Register addresses for these devices are pre-existing in the library and were already working via the unencrypted write path, so register correctness is expected. However, `DeviceReader.write()` is a new code path tested only on an AP300. 
**Owners of other encrypted devices are encouraged to test and report back.**

### HA integration changes
- `switch.py`, `select.py`: encrypted devices route writes through `coordinator.reader.write()` instead of `DeviceWriter`
- `binary_sensor.py`, `sensor.py`: switch/select fields no longer demoted to read-only entities on encrypted devices
- `number.py` (new): `NumberEntity` for `NumberField` types (SOC sliders)
- `__init__.py`: registers `Platform.NUMBER`
- `translations/en.json`: labels for working mode, charging mode, display timeout, charge-from-grid, SOC range fields

### UX details
- Charge-from-grid switch is marked **unavailable** unless working mode is set to Custom to match behavior in bluetti app
- SOC sliders reject inverted ranges (min > max)
- All dropdown/select options have human-readable labels

---

## Dependency

This PR depends on a companion library PR:
**[Patrick762/bluetti-bt-lib#58 — AP300: Add sensors, controls, and encrypted write support](https://github.com/Patrick762/bluetti-bt-lib/pull/58)**

Until that PR is merged and a new version is published to PyPI, `manifest.json`
temporarily references the fork:

```json
"requirements": ["bluetti-bt-lib@git+https://github.com/happytechca/bluetti-bt-lib.git@main"]
```

**This will be updated to a pinned PyPI version before this PR is merged.**

## Testing
You can test this PR today without waiting for the upstream library merge.

## Option A: HACS custom repository (easiest)
1. In HACS → Integrations → ⋮ → Custom repositories
2. Add https://github.com/happytechca/hassio-bluetti-bt (category: Integration)
3. Install it, then restart HA
4. The manifest.json automatically pulls the updated library from the fork
## Option B: Manual install
1. Copy custom_components/bluetti_bt/ from this repo into your HA custom_components/ folder
2. Restart HA — it will pull the library dependency on startup


### Summary

**AP300 (confirmed working):** All sensors, switches, selects, and number sliders tested on a physical Apex 300 unit.

**Other encrypted V2 devices (AC180, AC300, AC500, EP500P, EP600):**
Switches and selects will now appear as writable entities instead of read-only. Register addresses are unchanged from the library's existing definitions. The new encrypted write path is untested on these devices.
_Please test and report results in this PR._

**Unencrypted devices:** Completely unaffected by this PR.