### PR TITLE
AP300: add number platform and controls support

### DIFF
--- a/custom_components/bluetti_bt/__init__.py
+++ b/custom_components/bluetti_bt/__init__.py
@@ -24,6 +24,7 @@ from .coordinator import PollingCoordinator
 
 PLATFORMS: List[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.SELECT,

--- a/custom_components/bluetti_bt/number.py
+++ b/custom_components/bluetti_bt/number.py
@@ -1,0 +1,264 @@
+"""Bluetti BT numbers."""
+
+from __future__ import annotations
+import asyncio
+import logging
+import async_timeout
+from bleak import BleakScanner
+from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
+from homeassistant.components.number import NumberEntity, NumberMode
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+)
+from homeassistant.exceptions import ServiceValidationError
+
+from bluetti_bt_lib import (
+    build_device,
+    BluettiDevice,
+    DeviceWriter,
+    FieldName,
+    NumberField,
+)
+
+from .types import FullDeviceConfig, get_category
+from . import device_info as dev_info, get_unique_id
+from .const import DATA_COORDINATOR, DATA_LOCK, DOMAIN
+from .coordinator import PollingCoordinator
+from .utils import mac_loggable, unique_id_logable
+
+# Paired SOC fields: when setting one, validate against the other
+SOC_PAIRS = {
+    FieldName.BATTERY_SOC_RANGE_START.value: FieldName.BATTERY_SOC_RANGE_END.value,
+    FieldName.BATTERY_SOC_RANGE_END.value: FieldName.BATTERY_SOC_RANGE_START.value,
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Setup number entities."""
+
+    config = FullDeviceConfig.from_dict(entry.data)
+    coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+    lock = hass.data[DOMAIN][entry.entry_id][DATA_LOCK]
+
+    logger = logging.getLogger(
+        f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
+    )
+
+    if config is None or not isinstance(coordinator, PollingCoordinator):
+        logger.error("No coordinator found")
+        return None
+
+    # Generate device info
+    logger.info("Creating numbers for device with address %s", config.address)
+    device_info = dev_info(entry)
+
+    # Add numbers
+    bluetti_device = build_device(config.name)
+
+    numbers_to_add = []
+    number_fields = bluetti_device.get_number_fields()
+    for field in number_fields:
+        category = get_category(FieldName(field.name))
+
+        numbers_to_add.append(
+            BluettiNumber(
+                bluetti_device,
+                config.address,
+                coordinator,
+                device_info,
+                field,
+                lock,
+                category=category,
+                logger=logger,
+            )
+        )
+
+    async_add_entities(numbers_to_add)
+
+
+class BluettiNumber(CoordinatorEntity, NumberEntity):
+    """Bluetti universal number."""
+
+    def __init__(
+        self,
+        bluetti_device: BluettiDevice,
+        address: str,
+        coordinator: PollingCoordinator,
+        device_info: DeviceInfo,
+        field: NumberField,
+        lock: asyncio.Lock,
+        category: EntityCategory | None = None,
+        logger: logging.Logger = logging.getLogger(),
+    ) -> None:
+        """Init entity."""
+        super().__init__(coordinator)
+        self.coordinator = coordinator
+        self._logger = logger
+
+        e_name = f"{device_info.get('name')} {field.name}"
+        self._bluetti_device = bluetti_device
+        self._address = address
+        self._field = field
+        self._response_key = field.name
+        self._unavailable_counter = 5
+        self._lock = lock
+
+        self._attr_has_entity_name = True
+        self._attr_device_info = device_info
+        self._attr_translation_key = field.name
+        self._attr_available = False
+        self._attr_unique_id = get_unique_id(e_name)
+        self._attr_entity_category = category
+        self._attr_native_min_value = float(field.min) if field.min is not None else 0
+        self._attr_native_max_value = float(field.max) if field.max is not None else 100
+        self._attr_native_step = 1
+        self._attr_mode = NumberMode.SLIDER
+
+    @property
+    def available(self) -> bool:
+        """Return if entity is available."""
+        return self._attr_available
+
+    def _set_available(self) -> None:
+        """Set number as available."""
+        self._attr_available = True
+        self._unavailable_counter = 0
+        self._attr_extra_state_attributes = {}
+        self.async_write_ha_state()
+
+    def _set_unavailable(self, cause: str = "Unknown") -> None:
+        """Set number as unavailable."""
+        self._unavailable_counter += 1
+
+        self._attr_extra_state_attributes = {
+            "unavailable_counter": self._unavailable_counter,
+            "unavailable_cause": cause,
+        }
+
+        if self._unavailable_counter >= 5:
+            self._attr_available = False
+
+        self.async_write_ha_state()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+
+        if self.coordinator.data is None:
+            self._logger.debug(
+                "Data from coordinator is None",
+            )
+            self._set_unavailable("Data is None")
+            return
+
+        self._logger.debug(
+            "Updating state of %s", unique_id_logable(self._attr_unique_id)
+        )
+        if not isinstance(self.coordinator.data, dict):
+            self._logger.debug(
+                "Invalid data from coordinator (number.%s)",
+                unique_id_logable(self._attr_unique_id),
+            )
+            self._set_unavailable("Invalid data")
+            return
+
+        response_data = self.coordinator.data.get(self._response_key)
+        if response_data is None:
+            self._set_unavailable("No data")
+            return
+
+        if not isinstance(response_data, (int, float)):
+            self._logger.warning(
+                "Invalid response data type from coordinator (number.%s): %s",
+                unique_id_logable(self._attr_unique_id),
+                response_data,
+            )
+            self._set_unavailable("Invalid data type")
+            return
+
+        self._set_available()
+        self._attr_native_value = float(response_data)
+        self.async_write_ha_state()
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set the number value."""
+        int_value = int(value)
+
+        # SOC range guard: ensure start < end
+        self._validate_soc_range(int_value)
+
+        self._logger.debug(
+            "Set %s on %s to %s",
+            self._response_key,
+            mac_loggable(self._address),
+            int_value,
+        )
+        await self._write_to_device(int_value)
+
+    def _validate_soc_range(self, new_value: int) -> None:
+        """Validate SOC range constraints: start must be less than end."""
+        sibling_key = SOC_PAIRS.get(self._response_key)
+        if sibling_key is None:
+            return
+
+        sibling_value = None
+        if self.coordinator.data is not None:
+            sibling_value = self.coordinator.data.get(sibling_key)
+
+        if sibling_value is None:
+            return
+
+        sibling_value = int(sibling_value)
+
+        if self._response_key == FieldName.BATTERY_SOC_RANGE_START.value:
+            if new_value >= sibling_value:
+                raise ServiceValidationError(
+                    f"SOC range start ({new_value}%) must be less than "
+                    f"SOC range end ({sibling_value}%)"
+                )
+        elif self._response_key == FieldName.BATTERY_SOC_RANGE_END.value:
+            if new_value <= sibling_value:
+                raise ServiceValidationError(
+                    f"SOC range end ({new_value}%) must be greater than "
+                    f"SOC range start ({sibling_value}%)"
+                )
+
+    async def _write_to_device(self, value: int) -> None:
+        """Write an integer value to the device field."""
+        try:
+            device = await BleakScanner.find_device_by_address(self._address, timeout=5)
+
+            if device is None:
+                return
+
+            client = await establish_connection(
+                BleakClientWithServiceCache,
+                device,
+                device.name or "Unknown Device",
+                max_attempts=10,
+            )
+
+            if not client.is_connected:
+                return
+
+            writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
+
+            async with async_timeout.timeout(15):
+                # Send command
+                await writer.write(self._field.name, value)
+
+                # Wait until device has changed value, otherwise reading register might reset it
+                await asyncio.sleep(5)
+
+        except TimeoutError:
+            self._logger.error("Timed out for device %s", mac_loggable(self._address))
+            return None
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/bluetti_bt/translations/de.json
+++ b/custom_components/bluetti_bt/translations/de.json
@@ -303,6 +303,17 @@
       },
       "ctrl_power_off": {
         "name": "Ausschalter"
+      },
+      "ctrl_charge_from_grid": {
+        "name": "Vom Netz laden"
+      }
+    },
+    "number": {
+      "soc_range_start": {
+        "name": "SOC Min"
+      },
+      "soc_range_end": {
+        "name": "SOC Max"
       }
     },
     "select": {
@@ -326,6 +337,15 @@
       },
       "ctrl_ups_mode": {
         "name": "UPS Modus"
+      },
+      "ctrl_working_mode": {
+        "name": "Betriebsmodus",
+        "state": {
+          "CUSTOM": "Benutzerdefiniert",
+          "SELF_CONSUMPTION": "Eigenverbrauch",
+          "BACKUP": "Backup",
+          "TIME_OF_USE": "Zeitbasiert"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/bluetti_bt/translations/en.json
+++ b/custom_components/bluetti_bt/translations/en.json
@@ -303,6 +303,17 @@
       },
       "ctrl_power_off": {
         "name": "Poweroff"
+      },
+      "ctrl_charge_from_grid": {
+        "name": "Charge from Grid"
+      }
+    },
+    "number": {
+      "soc_range_start": {
+        "name": "SOC Min"
+      },
+      "soc_range_end": {
+        "name": "SOC Max"
       }
     },
     "select": {
@@ -326,6 +337,15 @@
       },
        "ctrl_ups_mode": {
         "name": "UPS Mode"
+      },
+      "ctrl_working_mode": {
+        "name": "Working Mode",
+        "state": {
+          "CUSTOM": "Custom",
+          "SELF_CONSUMPTION": "Self Consumption",
+          "BACKUP": "Backup",
+          "TIME_OF_USE": "Time of Use"
+        }
       }
     },
     "binary_sensor": {

--- a/custom_components/bluetti_bt/translations/pt.json
+++ b/custom_components/bluetti_bt/translations/pt.json
@@ -212,6 +212,28 @@
       },
       "ctrl_power_off": {
         "name": "Poweroff"
+      },
+      "ctrl_charge_from_grid": {
+        "name": "Carregar da Rede"
+      }
+    },
+    "number": {
+      "soc_range_start": {
+        "name": "SOC Min"
+      },
+      "soc_range_end": {
+        "name": "SOC Max"
+      }
+    },
+    "select": {
+      "ctrl_working_mode": {
+        "name": "Modo de Operação",
+        "state": {
+          "CUSTOM": "Personalizado",
+          "SELF_CONSUMPTION": "Autoconsumo",
+          "BACKUP": "Backup",
+          "TIME_OF_USE": "Horário"
+        }
       }
     }
   }

--- a/custom_components/bluetti_bt/types/FieldCategory.py
+++ b/custom_components/bluetti_bt/types/FieldCategory.py
@@ -25,6 +25,10 @@ CONFIGS = [
     FieldName.CTRL_POWER_LIFTING,
     FieldName.CTRL_SPLIT_PHASE,
     FieldName.CTRL_UPS_MODE,
+    FieldName.CTRL_WORKING_MODE,
+    FieldName.CTRL_CHARGE_FROM_GRID,
+    FieldName.BATTERY_SOC_RANGE_START,
+    FieldName.BATTERY_SOC_RANGE_END,
 ]
 
 


### PR DESCRIPTION
## Summary

Adds Home Assistant support for AP300 device controls introduced in [bluetti-bt-lib PR #61](https://github.com/Patrick762/bluetti-bt-lib/pull/61):

- **New number platform** (`number.py`): slider entities for battery SOC range start/end (0–100%), with validation guard preventing start ≥ end
- **Platform.NUMBER** added to PLATFORMS list in `__init__.py`
- **Translations** (en/de/pt): added `ctrl_charge_from_grid` switch, `ctrl_working_mode` select with state labels, `soc_range_start`/`soc_range_end` number entities
- **FieldCategory**: added `CTRL_WORKING_MODE`, `CTRL_CHARGE_FROM_GRID`, `BATTERY_SOC_RANGE_START`, `BATTERY_SOC_RANGE_END` to CONFIGS list

### Dependencies

- Requires [bluetti-bt-lib PR #61](https://github.com/Patrick762/bluetti-bt-lib/pull/61) for `NumberField`, `WorkingMode` enum, and the expanded AP300 device model
- Control writes on encrypted devices (like AP300) require [bluetti-bt-lib PR #59](https://github.com/Patrick762/bluetti-bt-lib/pull/59) (encrypted write support) and [PR #60](https://github.com/Patrick762/bluetti-bt-lib/pull/60) (persistent BLE connection)

### Notes

- The number platform follows the same write pattern as existing switch/select platforms (BleakScanner → establish_connection → DeviceWriter)
- SOC range validation raises `ServiceValidationError` with a descriptive message if the user tries to set invalid ranges
- Tested on a real AP300 device

---

## 🧪 Testing with full AP300 support (before PRs are merged)

If you have an AP300 and want to test the **full working integration** (sensors + controls including encrypted writes and persistent BLE connection), you can use the combined test branches. These include the work from PRs #59, #60, and #61 all together.

### Step-by-step instructions

#### 1. Install the custom integration via HACS

1. Open Home Assistant → **HACS** → **Integrations**
2. Click the **three dots** (⋮) in the top right → **Custom repositories**
3. Add this repository URL:
   ```
   https://github.com/happytechca/hassio-bluetti-bt
   ```
   Category: **Integration**
4. Click **Add**, then find **Bluetti BT** in HACS and click **Download**
5. When prompted for a version/branch, select the **`ap300-combined`** branch

#### 2. Restart Home Assistant

Go to **Settings** → **System** → **Restart**

#### 3. Add your Bluetti device

1. Go to **Settings** → **Devices & Services** → **Add Integration**
2. Search for **Bluetti BT**
3. Select your AP300 from the discovered devices

#### What you get

- All AP300 sensors (power, voltage, current, frequency, time remaining)
- Switch controls (AC/DC output, ECO modes, power lifting, charge from grid)
- Select controls (charging mode, working mode, display timeout)
- Number sliders (battery SOC range min/max with validation)
- Encrypted BLE writes with persistent connection (fast command response)

#### Reverting back

To go back to the official version once the PRs are merged:
1. In HACS, remove the custom repository
2. Install the official **Bluetti BT** integration from HACS

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)