### PR TITLE
Encrypted device write support with persistent BLE connection (AC180P and others)

### DIFF
--- a/custom_components/bluetti_bt/__init__.py
+++ b/custom_components/bluetti_bt/__init__.py
@@ -12,8 +12,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.exceptions import ConfigEntryNotReady
 
+from bluetti_bt_lib import DeviceConnection
+
 from .utils import mac_loggable
 from .const import (
+    DATA_CONNECTION,
     DATA_COORDINATOR,
     DATA_LOCK,
     DOMAIN,
@@ -51,8 +54,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault(entry.entry_id, {})
 
-    # Create lock
+    # Create shared BLE connection, lock, and write_pending event
     lock = asyncio.Lock()
+    write_pending = asyncio.Event()
+    connection = DeviceConnection(
+        config.address,
+        use_encryption=config.use_encryption,
+    )
+
+    hass.data[DOMAIN][entry.entry_id][DATA_LOCK] = lock
+    hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION] = connection
 
     # Create coordinator for polling
     logger.debug("Creating coordinator")
@@ -60,10 +71,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         hass,
         config,
         lock,
+        write_pending,
+        connection,
     )
     await coordinator.async_config_entry_first_refresh()
-    hass.data[DOMAIN][entry.entry_id].setdefault(DATA_COORDINATOR, coordinator)
-    hass.data[DOMAIN][entry.entry_id].setdefault(DATA_LOCK, lock)
+    hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR] = coordinator
 
     logger.debug("Creating entities")
     # Setup platforms
@@ -72,6 +84,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     logger.debug("Setup done")
 
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Bluetti Powerstation config entry."""
+    connection = hass.data[DOMAIN][entry.entry_id].get(DATA_CONNECTION)
+    if connection is not None:
+        await connection.disconnect()
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
 def device_info(entry: ConfigEntry):

--- a/custom_components/bluetti_bt/const.py
+++ b/custom_components/bluetti_bt/const.py
@@ -7,3 +7,4 @@ CONF_OPTIONS = "options"
 
 DATA_COORDINATOR = "coordinator"
 DATA_LOCK = "lock"
+DATA_CONNECTION = "connection"

--- a/custom_components/bluetti_bt/coordinator.py
+++ b/custom_components/bluetti_bt/coordinator.py
@@ -7,7 +7,7 @@ import logging
 from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from bluetti_bt_lib import build_device, DeviceReader, DeviceReaderConfig
+from bluetti_bt_lib import build_device, DeviceConnection, DeviceReader, DeviceReaderConfig
 
 from .utils import mac_loggable
 from .types import FullDeviceConfig
@@ -21,7 +21,9 @@ class PollingCoordinator(DataUpdateCoordinator):
         hass: HomeAssistant,
         config: FullDeviceConfig,
         lock: asyncio.Lock,
-    ):
+        write_pending: asyncio.Event,
+        connection: DeviceConnection,
+    ) -> None:
         """Initialize coordinator."""
         super().__init__(
             hass,
@@ -33,6 +35,7 @@ class PollingCoordinator(DataUpdateCoordinator):
         )
 
         self.config = config
+        self.write_pending = write_pending
 
         # Create client
         self.logger.info("Creating client for %s", config.name)
@@ -50,16 +53,19 @@ class PollingCoordinator(DataUpdateCoordinator):
             DeviceReaderConfig(
                 config.polling_timeout,
                 config.use_encryption,
+                keep_alive_seconds=config.polling_interval // 2,
             ),
             lock,
+            connection=connection,
         )
 
     async def _async_update_data(self):
-        """Fetch data from API endpoint.
+        """Fetch data from API endpoint."""
 
-        This is the place to pre-process the data to lookup tables
-        so entities can quickly look up their data.
-        """
+        # Skip read cycle if a write is in progress
+        if self.write_pending.is_set():
+            self.logger.debug("Write in progress, skipping read cycle")
+            return self.data
 
         # Check if device is connected
         if (

--- a/custom_components/bluetti_bt/select.py
+++ b/custom_components/bluetti_bt/select.py
@@ -1,11 +1,9 @@
-"""Bluetti BT switches."""
+"""Bluetti BT selects."""
 
 from __future__ import annotations
 import asyncio
 import logging
 import async_timeout
-from bleak import BleakScanner
-from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -16,12 +14,12 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
 
-from bluetti_bt_lib import build_device, BluettiDevice, DeviceWriter, FieldName
+from bluetti_bt_lib import build_device, BluettiDevice, DeviceConnection, DeviceWriter, DeviceWriterConfig, FieldName
 from bluetti_bt_lib.fields import SelectField
 
 from .types import FullDeviceConfig, get_category
 from . import device_info as dev_info, get_unique_id
-from .const import DATA_COORDINATOR, DATA_LOCK, DOMAIN
+from .const import DATA_CONNECTION, DATA_COORDINATOR, DATA_LOCK, DOMAIN
 from .coordinator import PollingCoordinator
 from .utils import mac_loggable, unique_id_logable
 
@@ -34,14 +32,11 @@ async def async_setup_entry(
     config = FullDeviceConfig.from_dict(entry.data)
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
     lock = hass.data[DOMAIN][entry.entry_id][DATA_LOCK]
+    connection = hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION]
 
     logger = logging.getLogger(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
-
-    if config.use_encryption is True:
-        logger.info("Controls are disabled on encrypted devices")
-        return None
 
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
@@ -51,44 +46,48 @@ async def async_setup_entry(
     logger.info("Creating selects for device with address %s", config.address)
     device_info = dev_info(entry)
 
-    # Add switches
+    # Add selects
     bluetti_device = build_device(config.name)
 
-    switches_to_add = []
-    switch_fields = bluetti_device.get_select_fields()
-    for field in switch_fields:
+    selects_to_add = []
+    select_fields = bluetti_device.get_select_fields()
+    for field in select_fields:
         category = get_category(FieldName(field.name))
 
-        switches_to_add.append(
+        selects_to_add.append(
             BluettiSelect(
                 bluetti_device,
                 config.address,
+                config.use_encryption,
                 coordinator,
                 device_info,
                 field,
                 lock,
+                connection,
                 category=category,
                 logger=logger,
             )
         )
 
-    async_add_entities(switches_to_add)
+    async_add_entities(selects_to_add)
 
 
 class BluettiSelect(CoordinatorEntity, SelectEntity):
-    """Bluetti universal switch."""
+    """Bluetti universal select."""
 
     def __init__(
         self,
         bluetti_device: BluettiDevice,
         address: str,
+        use_encryption: bool,
         coordinator: PollingCoordinator,
         device_info: DeviceInfo,
         field: SelectField,
         lock: asyncio.Lock,
+        connection: DeviceConnection,
         category: EntityCategory | None = None,
         logger: logging.Logger = logging.getLogger(),
-    ):
+    ) -> None:
         """Init entity."""
         super().__init__(coordinator)
         self.coordinator = coordinator
@@ -97,10 +96,12 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
         e_name = f"{device_info.get('name')} {field.name}"
         self._bluetti_device = bluetti_device
         self._address = address
+        self._use_encryption = use_encryption
         self._field = field
         self._response_key = field.name
         self._unavailable_counter = 5
         self._lock = lock
+        self._connection = connection
         self._attr_options = [e.name for e in field.e]
 
         self._attr_has_entity_name = True
@@ -116,14 +117,14 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
         return self._attr_available
 
     def _set_available(self):
-        """Set switch as available."""
+        """Set select as available."""
         self._attr_available = True
         self._unavailable_counter = 0
         self._attr_extra_state_attributes = {}
         self.async_write_ha_state()
 
     def _set_unavailable(self, cause: str = "Unknown"):
-        """Set switch as unavailable."""
+        """Set select as unavailable."""
         self._unavailable_counter += 1
 
         self._attr_extra_state_attributes = {
@@ -139,6 +140,9 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+
+        if self.coordinator.write_pending.is_set():
+            return
 
         if self.coordinator.data is None:
             self._logger.debug(
@@ -186,36 +190,30 @@ class BluettiSelect(CoordinatorEntity, SelectEntity):
         )
         await self.write_to_device(option)
 
-    async def write_to_device(self, state: str):
-        """Write to device."""
+    async def write_to_device(self, state: str) -> None:
+        """Write a string value to the device field."""
+        # Update UI immediately — don't wait for coordinator confirmation
+        self.current_option = state
+        self.async_write_ha_state()
 
+        self.coordinator.write_pending.set()
         try:
-            device = await BleakScanner.find_device_by_address(self._address, timeout=5)
-
-            if device is None:
-                return
-
-            client = await establish_connection(
-                BleakClientWithServiceCache,
-                device,
-                device.name or "Unknown Device",
-                max_attempts=10,
-            )
-
-            if not client.is_connected:
-                return
-
-            writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
-
-            async with async_timeout.timeout(15):
-                # Send command
+            async with async_timeout.timeout(60):
+                writer = self._create_writer()
                 await writer.write(self._field.name, state)
-
-                # Wait until device has changed value, otherwise reading register might reset it
-                await asyncio.sleep(5)
-
+                await asyncio.sleep(1)
         except TimeoutError:
             self._logger.error("Timed out for device %s", mac_loggable(self._address))
-            return None
+        finally:
+            self.coordinator.write_pending.clear()
+            await self.coordinator.async_request_refresh()
 
-        await self.coordinator.async_request_refresh()
+    def _create_writer(self) -> DeviceWriter:
+        """Build a DeviceWriter that uses the shared persistent connection."""
+        return DeviceWriter(
+            bleak_client=None,
+            bluetti_device=self._bluetti_device,
+            config=DeviceWriterConfig(timeout=30, use_encryption=self._use_encryption),
+            lock=self._lock,
+            connection=self._connection,
+        )

--- a/custom_components/bluetti_bt/switch.py
+++ b/custom_components/bluetti_bt/switch.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import async_timeout
-from bleak import BleakScanner
-from bleak_retry_connector import BleakClientWithServiceCache, establish_connection
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -19,14 +17,16 @@ from homeassistant.helpers.update_coordinator import (
 from bluetti_bt_lib import (
     build_device,
     BluettiDevice,
-    DeviceWriter,
+    DeviceConnection,
     DeviceField,
+    DeviceWriter,
+    DeviceWriterConfig,
     FieldName,
 )
 
 from .types import FullDeviceConfig, get_category
 from . import device_info as dev_info, get_unique_id
-from .const import DATA_COORDINATOR, DATA_LOCK, DOMAIN
+from .const import DATA_CONNECTION, DATA_COORDINATOR, DATA_LOCK, DOMAIN
 from .coordinator import PollingCoordinator
 from .utils import mac_loggable, unique_id_logable
 
@@ -39,14 +39,11 @@ async def async_setup_entry(
     config = FullDeviceConfig.from_dict(entry.data)
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
     lock = hass.data[DOMAIN][entry.entry_id][DATA_LOCK]
+    connection = hass.data[DOMAIN][entry.entry_id][DATA_CONNECTION]
 
     logger = logging.getLogger(
         f"{__name__}.{mac_loggable(config.address).replace(':', '_')}"
     )
-
-    if config.use_encryption is True:
-        logger.info("Controls are disabled on encrypted devices")
-        return None
 
     if config is None or not isinstance(coordinator, PollingCoordinator):
         logger.error("No coordinator found")
@@ -68,10 +65,12 @@ async def async_setup_entry(
             BluettiSwitch(
                 bluetti_device,
                 config.address,
+                config.use_encryption,
                 coordinator,
                 device_info,
                 field,
                 lock,
+                connection,
                 category=category,
                 logger=logger,
             )
@@ -87,13 +86,15 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
         self,
         bluetti_device: BluettiDevice,
         address: str,
+        use_encryption: bool,
         coordinator: PollingCoordinator,
         device_info: DeviceInfo,
         field: DeviceField,
         lock: asyncio.Lock,
+        connection: DeviceConnection,
         category: EntityCategory | None = None,
         logger: logging.Logger = logging.getLogger(),
-    ):
+    ) -> None:
         """Init entity."""
         super().__init__(coordinator)
         self.coordinator = coordinator
@@ -102,10 +103,12 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
         e_name = f"{device_info.get('name')} {field.name}"
         self._bluetti_device = bluetti_device
         self._address = address
+        self._use_encryption = use_encryption
         self._field = field
         self._response_key = field.name
         self._unavailable_counter = 5
         self._lock = lock
+        self._connection = connection
 
         self._attr_has_entity_name = True
         self._attr_device_info = device_info
@@ -143,6 +146,9 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+
+        if self.coordinator.write_pending.is_set():
+            return
 
         if self.coordinator.data is None:
             self._logger.debug(
@@ -194,36 +200,30 @@ class BluettiSwitch(CoordinatorEntity, SwitchEntity):
         )
         await self.write_to_device(False)
 
-    async def write_to_device(self, state: bool):
-        """Write to device."""
+    async def write_to_device(self, state: bool) -> None:
+        """Write a boolean value to the device field."""
+        # Update UI immediately — don't wait for coordinator confirmation
+        self._attr_is_on = state
+        self.async_write_ha_state()
 
+        self.coordinator.write_pending.set()
         try:
-            device = await BleakScanner.find_device_by_address(self._address, timeout=5)
-
-            if device is None:
-                return
-
-            client = await establish_connection(
-                BleakClientWithServiceCache,
-                device,
-                device.name or "Unknown Device",
-                max_attempts=10,
-            )
-
-            if not client.is_connected:
-                return
-
-            writer = DeviceWriter(client, self._bluetti_device, lock=self._lock)
-
-            async with async_timeout.timeout(15):
-                # Send command
+            async with async_timeout.timeout(60):
+                writer = self._create_writer()
                 await writer.write(self._field.name, state)
-
-                # Wait until device has changed value, otherwise reading register might reset it
-                await asyncio.sleep(5)
-
+                await asyncio.sleep(2)
         except TimeoutError:
             self._logger.error("Timed out for device %s", mac_loggable(self._address))
-            return None
+        finally:
+            self.coordinator.write_pending.clear()
+            await self.coordinator.async_request_refresh()
 
-        await self.coordinator.async_request_refresh()
+    def _create_writer(self) -> DeviceWriter:
+        """Build a DeviceWriter that uses the shared persistent connection."""
+        return DeviceWriter(
+            bleak_client=None,
+            bluetti_device=self._bluetti_device,
+            config=DeviceWriterConfig(timeout=30, use_encryption=self._use_encryption),
+            lock=self._lock,
+            connection=self._connection,
+        )


### PR DESCRIPTION
> [!WARNING]
> **Draft PR** — depends on two library PRs that must be merged and released before this can be merged (see Notes below).

## Problem

Controls (switches and selects) on encrypted devices were silently disabled. Even on unencrypted devices, every toggle opened a fresh BLE connection — taking 5–14 seconds per write.

This PR wires up the `DeviceConnection` introduced in the library (bluetti-bt-lib) so the integration shares a single persistent BLE session between the polling coordinator and the entity writer.

## What changed

### `__init__.py`

Creates a shared `DeviceConnection` and `write_pending` event on setup, stores them in `hass.data`, passes them to the coordinator, and disconnects cleanly on unload.

### `coordinator.py`

Accepts `connection` and `write_pending`. Passes `connection` to `DeviceReader` and sets `keep_alive_seconds = polling_interval // 2` so the BLE session stays alive briefly after each read cycle. Skips the read cycle entirely while a write is in progress.

### `switch.py` / `select.py`

- Removed the block that disabled controls on encrypted devices
- Write commands now use the shared `DeviceConnection` via `DeviceWriter` — no per-write reconnect
- Optimistic UI update applied immediately on toggle, before the write completes
- `write_pending` guard prevents the coordinator from overwriting the optimistic state during the write

### `const.py`

Added `DATA_CONNECTION` key.

## Tested on

Bluetti AC180P via ESPHome BLE proxy
AC output, DC output, Power Lifting, Charging Mode — all confirmed working

A test branch (using local library copies before the PRs land) is available here:
[defire04/hassio-bluetti-bt @ test-encrypted-writes-and-persistent-ble-connection](https://github.com/defire04/hassio-bluetti-bt/tree/test-encrypted-writes-and-persistent-ble-connection)

## Notes

This PR depends on two bluetti-bt-lib PRs — it cannot be merged until both land and a new library version is published:

- [bluetti-bt-lib: Enable write commands for encrypted Bluetti devices](https://github.com/Patrick762/bluetti-bt-lib/pull/59)
- [bluetti-bt-lib: Persistent BLE connection for instant writes](https://github.com/Patrick762/bluetti-bt-lib/pull/60)
