### PR TITLE
Add Bluetti Premium 100 V2 (PR100V2) support

### DIFF
--- a/custom_components/bluetti_bt/manifest.json
+++ b/custom_components/bluetti_bt/manifest.json
@@ -21,7 +21,9 @@
         { "local_name": "EP7*" },
         { "local_name": "EP8*" },
         { "local_name": "Handsfree*" },
-        { "local_name": "PBOX*" }
+        { "local_name": "PBOX*" },
+        { "local_name": "PR1*" },
+        { "local_name": "PR3*" }
     ],
     "codeowners": ["@Patrick762"],
     "config_flow": true,
@@ -30,6 +32,6 @@
     "integration_type": "device",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Patrick762/hassio-bluetti-bt/issues",
-    "requirements": ["bluetti-bt-lib==0.1.6"],
-    "version": "0.2.1"
+    "requirements": ["bluetti-bt-lib==0.1.7"],
+    "version": "0.2.2"
 }


### PR DESCRIPTION
@
Adds Home Assistant discovery support for the BLUETTI Premium 100 V2 (`PR100V2<serial>`).

### Changes
- Added `PR1*` Bluetooth `local_name` matcher so the Premium 100 V2 is auto-discovered.
- Added `PR3*` matcher as well: `PR30V2` already exists in the library but had no matcher (the device-name test only catches this once the library bump below brings `PR30V2` into the pinned release).
- Bumped `bluetti-bt-lib` requirement to `0.1.7` and the integration version to `0.2.2`.

### Dependency
> [!IMPORTANT]
> This depends on Patrick762/bluetti-bt-lib#70, which adds the `PR100V2` device class. CI here will fail until that PR is merged **and** `bluetti-bt-lib==0.1.7` is published to PyPI.

### Validation
- BT name prefix `PR100V2` confirmed from a physical device.
- Field registers (in the library PR) are inherited from the identical-layout `PR30V2`; I will validate live values against the BLUETTI app and report back.
@